### PR TITLE
Dump core booleans with !!1 and !!0 notation

### DIFF
--- a/lib/Data/Dump.pm
+++ b/lib/Data/Dump.pm
@@ -19,6 +19,13 @@ $TRY_BASE64 = 50 unless defined $TRY_BASE64;
 $INDENT = "  " unless defined $INDENT;
 $LINEWIDTH = 60 unless defined $LINEWIDTH;
 
+use constant HAVE_BOOLEANS => $^V ge v5.36.0;
+sub _is_bool
+{
+    no if HAVE_BOOLEANS, warnings => "experimental::builtin";
+    return HAVE_BOOLEANS ? builtin::is_bool($_[0]) : 0;
+}
+
 sub dump
 {
     local %seen;
@@ -229,6 +236,9 @@ sub _dump
 	} else {
 	    if (!defined $$rval) {
 		$out = "undef";
+	    }
+	    elsif (_is_bool $$rval) {
+	        $out = $$rval ? '!!1' : '!!0';
 	    }
 	    elsif ($$rval =~ /^-?(?:nan|inf)/i) {
 		$out = str($$rval);

--- a/t/boolean.t
+++ b/t/boolean.t
@@ -1,0 +1,13 @@
+if( $^V lt v5.36.0 ) {
+   print "1..0 # skip No core booleans\n";
+   exit 0;
+}
+
+print "1..1\n";
+
+use Data::Dump qw(dump);
+
+$d = dump([1 == 0, 1 == 1]);
+
+print "not " unless $d eq q([!!0, !!1]);
+print "ok 1\n";


### PR DESCRIPTION
These were added in Perl v5.36. Core's `Data::Dumper` already emits them in the back-compatible notation of `!!1` for true and `!!0` for false, so this should probably do similar.